### PR TITLE
Safe Haskell

### DIFF
--- a/microlens-ghc/src/Lens/Micro/GHC.hs
+++ b/microlens-ghc/src/Lens/Micro/GHC.hs
@@ -5,7 +5,8 @@ TypeFamilies,
 FlexibleContexts,
 FlexibleInstances,
 UndecidableInstances,
-BangPatterns
+BangPatterns,
+Trustworthy
   #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}

--- a/microlens-mtl/src/Lens/Micro/Mtl.hs
+++ b/microlens-mtl/src/Lens/Micro/Mtl.hs
@@ -3,7 +3,8 @@ MultiParamTypeClasses,
 FunctionalDependencies,
 FlexibleInstances,
 UndecidableInstances,
-TypeFamilies
+TypeFamilies,
+Trustworthy
   #-}
 
 -- This is needed because ErrorT is deprecated.

--- a/microlens-mtl/src/Lens/Micro/Mtl/Zoom.hs
+++ b/microlens-mtl/src/Lens/Micro/Mtl/Zoom.hs
@@ -8,7 +8,8 @@ UndecidableInstances,
 ScopedTypeVariables,
 RankNTypes,
 TypeFamilies,
-KindSignatures
+KindSignatures,
+Trustworthy
   #-}
 
 -- This is needed because ErrorT is deprecated.

--- a/microlens-platform/src/Lens/Micro/Platform.hs
+++ b/microlens-platform/src/Lens/Micro/Platform.hs
@@ -3,7 +3,8 @@ CPP,
 TypeFamilies,
 MultiParamTypeClasses,
 FlexibleInstances,
-UndecidableInstances
+UndecidableInstances,
+Trustworthy
   #-}
 
 -- without -fno-warn-dodgy-exports it complains about Lens.Micro.GHC

--- a/microlens/microlens.cabal
+++ b/microlens/microlens.cabal
@@ -16,7 +16,7 @@ description:
   .
     * if you think lenses compose “in the wrong order” (in which case you're looking for <http://hackage.haskell.org/package/fclabels fclabels>)
   .
-  If you're writing an application which uses lenses more extnesively, look at <http://hackage.haskell.org/package/microlens-platform microlens-platform> – it combines features of all other microlens packages (<http://hackage.haskell.org/package/microlens-mtl microlens-mtl>, <http://hackage.haskell.org/package/microlens-th microlens-th>, <http://hackage.haskell.org/package/microlens-ghc microlens-ghc>).
+  If you're writing an application which uses lenses more extensively, look at <http://hackage.haskell.org/package/microlens-platform microlens-platform> – it combines features of all other microlens packages (<http://hackage.haskell.org/package/microlens-mtl microlens-mtl>, <http://hackage.haskell.org/package/microlens-th microlens-th>, <http://hackage.haskell.org/package/microlens-ghc microlens-ghc>).
   .
   There's a longer readme <https://github.com/aelve/microlens#readme on Github>, you should read it if you're still interested about using this library.
   .

--- a/microlens/src/Lens/Micro.hs
+++ b/microlens/src/Lens/Micro.hs
@@ -4,7 +4,8 @@ FlexibleInstances,
 FlexibleContexts,
 UndecidableInstances,
 RankNTypes,
-ScopedTypeVariables
+ScopedTypeVariables,
+Trustworthy
   #-}
 
 

--- a/microlens/src/Lens/Micro/Internal.hs
+++ b/microlens/src/Lens/Micro/Internal.hs
@@ -9,7 +9,8 @@ DefaultSignatures,
 KindSignatures,
 TypeFamilies,
 MultiParamTypeClasses,
-FunctionalDependencies
+FunctionalDependencies,
+Unsafe
   #-}
 
 

--- a/microlens/src/Lens/Micro/Type.hs
+++ b/microlens/src/Lens/Micro/Type.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE
-RankNTypes
+RankNTypes,
+Safe
   #-}
 
 


### PR DESCRIPTION
I had originally intended to create a `Lens.Micro.Internal.Unsafe` module, but that might break some configurations and so would be a major version bump. Instead, `Lens.Micro.Internal` is marked Unsafe; given its expected use, I don't think that will be a problem.