### PR TITLE
Minor whitespace fixes to microlens-th.cabal

### DIFF
--- a/microlens-th/microlens-th.cabal
+++ b/microlens-th/microlens-th.cabal
@@ -28,8 +28,8 @@ flag inlining
 
 library
   exposed-modules:     Lens.Micro.TH
-  -- other-modules:       
-  -- other-extensions:    
+  -- other-modules:
+  -- other-extensions:
   build-depends:       base >=4.5 && <5
                      , microlens >=0.3.2 && <0.4
                      , containers >=0.4.0 && <0.6


### PR DESCRIPTION
Remove trailing whitespace and add newline to end of file.